### PR TITLE
DM-53861: Bump image tag in prod kustomizations for all instruments

### DIFF
--- a/kubernetes/overlays/prod/latiss-cronjob/kustomization.yaml
+++ b/kubernetes/overlays/prod/latiss-cronjob/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/lsst-dm/consdb-transformed-efd
-  newTag: "25.10.2"
+  newTag: "26.2.1"
 
 resources:
 - ../../../base/cronjob/

--- a/kubernetes/overlays/prod/latiss-job/kustomization.yaml
+++ b/kubernetes/overlays/prod/latiss-job/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/lsst-dm/consdb-transformed-efd
-  newTag: "25.10.2"
+  newTag: "26.2.1"
 
 resources:
 - ../../../base/job/

--- a/kubernetes/overlays/prod/lsstcam-cronjob/kustomization.yaml
+++ b/kubernetes/overlays/prod/lsstcam-cronjob/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/lsst-dm/consdb-transformed-efd
-  newTag: "25.10.2"
+  newTag: "26.2.1"
 
 resources:
 - ../../../base/cronjob/

--- a/kubernetes/overlays/prod/lsstcam-job/kustomization.yaml
+++ b/kubernetes/overlays/prod/lsstcam-job/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/lsst-dm/consdb-transformed-efd
-  newTag: "25.10.2"
+  newTag: "26.2.1"
 
 resources:
 - ../../../base/job/

--- a/kubernetes/overlays/prod/lsstcomcam-cronjob/kustomization.yaml
+++ b/kubernetes/overlays/prod/lsstcomcam-cronjob/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/lsst-dm/consdb-transformed-efd
-  newTag: "25.10.2"
+  newTag: "26.2.1"
 
 resources:
 - ../../../base/cronjob/

--- a/kubernetes/overlays/prod/lsstcomcam-job/kustomization.yaml
+++ b/kubernetes/overlays/prod/lsstcomcam-job/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/lsst-dm/consdb-transformed-efd
-  newTag: "25.10.2"
+  newTag: "26.2.1"
 
 resources:
 - ../../../base/job/


### PR DESCRIPTION
Update image tag to 26.2.1 in prod kustomizations for all instruments.