### PR TITLE
DM-54483: Update Multi-DB overlays and refactored failure monitoring

### DIFF
--- a/kubernetes/base/Makefile
+++ b/kubernetes/base/Makefile
@@ -44,6 +44,7 @@ endif
 SECRET_KEYS ?= aws-access-key-id \
                aws-secret-access-key \
                consdb-url \
+			   consdb-int-url \
                consdb-url-dev \
                s3-profile-embargo \
                usdf-efd-password

--- a/kubernetes/base/cronjob/cronjob-template.yaml
+++ b/kubernetes/base/cronjob/cronjob-template.yaml
@@ -34,12 +34,12 @@ spec:
                   -e "$DATETIME_END" \
                   -i "$INSTRUMENT" \
                   -r "$BUTLER_REPO" \
-                  -d "$CONSDB_URL" \
+                  -d "$CONSDB_URL" ${CONSDB_INT_URL:+"$CONSDB_INT_URL"} \
                   -E "$EFD" \
                   -t "$TIMEDELTA" \
                   -w "$TIMEWINDOW" \
                   -m "$MODE" \
-                  ${RESUME:+$RESUME}
+                  ${FAILURE_MONITOR:+$FAILURE_MONITOR}
             env:
             # --- Instrument-Specific (Override in overlays) ---
             - name: CONFIG_FILE
@@ -52,8 +52,8 @@ spec:
               value: "1"            # Time overlap between a chunk and the next one (minutes)
             - name: MODE
               value: "cronjob"
-            - name: RESUME
-              value: ""      # -R or --resume Flag to resume processing from the last successful chunk
+            - name: FAILURE_MONITOR
+              value: ""      # --failure-monitor Flag to monitor failures
             # --- Secrets (Environment-specific)
             - name: CONSDB_URL
               valueFrom:

--- a/kubernetes/base/job/job-template.yaml
+++ b/kubernetes/base/job/job-template.yaml
@@ -30,7 +30,7 @@ spec:
               -e "$DATETIME_END" \
               -i "$INSTRUMENT" \
               -r "$BUTLER_REPO" \
-              -d "$CONSDB_URL" \
+              -d "$CONSDB_URL" ${CONSDB_INT_URL:+"$CONSDB_INT_URL"} \
               -E "$EFD" \
               -t "$TIMEDELTA" \
               -w "$TIMEWINDOW" \

--- a/kubernetes/overlays/dev/latiss-cronjob/failure-monitor.yaml
+++ b/kubernetes/overlays/dev/latiss-cronjob/failure-monitor.yaml
@@ -15,8 +15,8 @@ spec:
               value: "LATISS"
             - name: CONFIG_FILE
               value: "/opt/lsst/software/stack/python/lsst/consdb/transformed_efd/config/config_latiss.yaml"
-            - name: RESUME
-              value: "--resume"     # -R or --resume Flag to resume processing from the last successful chunk
+            - name: FAILURE_MONITOR
+              value: "--failure-monitor --monitor-window-days 7"
             - name: CONSDB_URL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/overlays/dev/lsstcam-cronjob/failure-monitor.yaml
+++ b/kubernetes/overlays/dev/lsstcam-cronjob/failure-monitor.yaml
@@ -15,8 +15,8 @@ spec:
               value: "LSSTCam"
             - name: CONFIG_FILE
               value: "/opt/lsst/software/stack/python/lsst/consdb/transformed_efd/config/config_lsstcam.yaml"
-            - name: RESUME
-              value: "--resume"     # -R or --resume Flag to resume processing from the last successful chunk
+            - name: FAILURE_MONITOR
+              value: "--failure-monitor --monitor-window-days 7"
             - name: CONSDB_URL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/overlays/dev/lsstcomcam-cronjob/failure-monitor.yaml
+++ b/kubernetes/overlays/dev/lsstcomcam-cronjob/failure-monitor.yaml
@@ -15,8 +15,8 @@ spec:
               value: "LSSTComCam"
             - name: CONFIG_FILE
               value: "/opt/lsst/software/stack/python/lsst/consdb/transformed_efd/config/config_lsstcomcam.yaml"
-            - name: RESUME
-              value: "--resume"     # -R or --resume Flag to resume processing from the last successful chunk              
+            - name: FAILURE_MONITOR
+              value: "--failure-monitor --monitor-window-days 7"
             - name: CONSDB_URL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/overlays/prod/env.mk
+++ b/kubernetes/overlays/prod/env.mk
@@ -3,5 +3,6 @@ SECRET_PATH ?= secret/rubin/usdf-consdb
 SECRET_KEYS ?= aws-access-key-id \
                aws-secret-access-key \
                consdb-url \
+               consdb-int-url \
                s3-profile-embargo \
                usdf-efd-password

--- a/kubernetes/overlays/prod/latiss-cronjob/cronjob.yaml
+++ b/kubernetes/overlays/prod/latiss-cronjob/cronjob.yaml
@@ -24,5 +24,10 @@ spec:
                 secretKeyRef:
                   name: efd-transform-secrets
                   key: consdb-url
+            - name: CONSDB_INT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: efd-transform-secrets
+                  key: consdb-int-url
             - name: BUTLER_REPO
               value: "s3://embargo@rubin-summit-users/butler.yaml"

--- a/kubernetes/overlays/prod/latiss-cronjob/failure-monitor.yaml
+++ b/kubernetes/overlays/prod/latiss-cronjob/failure-monitor.yaml
@@ -15,12 +15,17 @@ spec:
               value: "LATISS"
             - name: CONFIG_FILE
               value: "/opt/lsst/software/stack/python/lsst/consdb/transformed_efd/config/config_latiss.yaml"
-            - name: RESUME
-              value: "--resume"     # -R or --resume Flag to resume processing from the last successful chunk
+            - name: FAILURE_MONITOR
+              value: "--failure-monitor --monitor-window-days 7"
             - name: CONSDB_URL
               valueFrom:
                 secretKeyRef:
                   name: efd-transform-secrets
                   key: consdb-url
+            - name: CONSDB_INT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: efd-transform-secrets
+                  key: consdb-int-url
             - name: BUTLER_REPO
               value: "s3://embargo@rubin-summit-users/butler.yaml"

--- a/kubernetes/overlays/prod/latiss-cronjob/failure-monitor.yaml
+++ b/kubernetes/overlays/prod/latiss-cronjob/failure-monitor.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: transformed-efd-prod-failure-monitor
 spec:
-  schedule: "*/60 * * * *"
+  schedule: "0 */6 * * *"
   jobTemplate:
     spec:
       template:

--- a/kubernetes/overlays/prod/latiss-cronjob/kustomization.yaml
+++ b/kubernetes/overlays/prod/latiss-cronjob/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/lsst-dm/consdb-transformed-efd
-  newTag: "26.2.1"
+  newTag: "26.3.4"
 
 resources:
 - ../../../base/cronjob/

--- a/kubernetes/overlays/prod/latiss-cronjob/kustomization.yaml
+++ b/kubernetes/overlays/prod/latiss-cronjob/kustomization.yaml
@@ -17,6 +17,7 @@ secretGenerator:
   - s3-profile-embargo=etc/.secrets/s3-profile-embargo
   - usdf-efd-password=etc/.secrets/usdf-efd-password
   - consdb-url=etc/.secrets/consdb-url
+  - consdb-int-url=etc/.secrets/consdb-int-url
 
 namespace: prod-latiss
 

--- a/kubernetes/overlays/prod/latiss-job/job.yaml
+++ b/kubernetes/overlays/prod/latiss-job/job.yaml
@@ -25,6 +25,11 @@ spec:
               secretKeyRef:
                 name: efd-transform-secrets
                 key: consdb-url
+          - name: CONSDB_INT_URL
+            valueFrom:
+              secretKeyRef:
+                name: efd-transform-secrets
+                key: consdb-int-url
           - name: BUTLER_REPO
             value: "s3://embargo@rubin-summit-users/butler.yaml"
           

--- a/kubernetes/overlays/prod/latiss-job/kustomization.yaml
+++ b/kubernetes/overlays/prod/latiss-job/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/lsst-dm/consdb-transformed-efd
-  newTag: "26.2.1"
+  newTag: "26.3.4"
 
 resources:
 - ../../../base/job/

--- a/kubernetes/overlays/prod/latiss-job/kustomization.yaml
+++ b/kubernetes/overlays/prod/latiss-job/kustomization.yaml
@@ -17,6 +17,7 @@ secretGenerator:
   - s3-profile-embargo=etc/.secrets/s3-profile-embargo
   - usdf-efd-password=etc/.secrets/usdf-efd-password
   - consdb-url=etc/.secrets/consdb-url
+  - consdb-int-url=etc/.secrets/consdb-int-url
 
 namespace: prod-latiss
 

--- a/kubernetes/overlays/prod/latiss-job/patch.yaml
+++ b/kubernetes/overlays/prod/latiss-job/patch.yaml
@@ -1,1 +1,1 @@
-2023-legacy.yaml
+job.yaml

--- a/kubernetes/overlays/prod/lsstcam-cronjob/cronjob.yaml
+++ b/kubernetes/overlays/prod/lsstcam-cronjob/cronjob.yaml
@@ -24,5 +24,10 @@ spec:
                 secretKeyRef:
                   name: efd-transform-secrets
                   key: consdb-url
+            - name: CONSDB_INT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: efd-transform-secrets
+                  key: consdb-int-url
             - name: BUTLER_REPO
               value: "s3://embargo@rubin-summit-users/butler.yaml"

--- a/kubernetes/overlays/prod/lsstcam-cronjob/failure-monitor.yaml
+++ b/kubernetes/overlays/prod/lsstcam-cronjob/failure-monitor.yaml
@@ -15,12 +15,17 @@ spec:
               value: "LSSTCam"
             - name: CONFIG_FILE
               value: "/opt/lsst/software/stack/python/lsst/consdb/transformed_efd/config/config_lsstcam.yaml"
-            - name: RESUME
-              value: "--resume"     # -R or --resume Flag to resume processing from the last successful chunk
+            - name: FAILURE_MONITOR
+              value: "--failure-monitor --monitor-window-days 7"
             - name: CONSDB_URL
               valueFrom:
                 secretKeyRef:
                   name: efd-transform-secrets
                   key: consdb-url
+            - name: CONSDB_INT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: efd-transform-secrets
+                  key: consdb-int-url
             - name: BUTLER_REPO
               value: "s3://embargo@rubin-summit-users/butler.yaml"

--- a/kubernetes/overlays/prod/lsstcam-cronjob/failure-monitor.yaml
+++ b/kubernetes/overlays/prod/lsstcam-cronjob/failure-monitor.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: transformed-efd-prod-failure-monitor
 spec:
-  schedule: "*/60 * * * *"
+  schedule: "0 */6 * * *"
   jobTemplate:
     spec:
       template:

--- a/kubernetes/overlays/prod/lsstcam-cronjob/kustomization.yaml
+++ b/kubernetes/overlays/prod/lsstcam-cronjob/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/lsst-dm/consdb-transformed-efd
-  newTag: "26.2.1"
+  newTag: "26.3.4"
 
 resources:
 - ../../../base/cronjob/

--- a/kubernetes/overlays/prod/lsstcam-cronjob/kustomization.yaml
+++ b/kubernetes/overlays/prod/lsstcam-cronjob/kustomization.yaml
@@ -17,6 +17,7 @@ secretGenerator:
   - s3-profile-embargo=etc/.secrets/s3-profile-embargo
   - usdf-efd-password=etc/.secrets/usdf-efd-password
   - consdb-url=etc/.secrets/consdb-url
+  - consdb-int-url=etc/.secrets/consdb-int-url
 
 namespace: prod-lsstcam
 

--- a/kubernetes/overlays/prod/lsstcam-job/job.yaml
+++ b/kubernetes/overlays/prod/lsstcam-job/job.yaml
@@ -25,6 +25,11 @@ spec:
               secretKeyRef:
                 name: efd-transform-secrets
                 key: consdb-url
+          - name: CONSDB_INT_URL
+            valueFrom:
+              secretKeyRef:
+                name: efd-transform-secrets
+                key: consdb-int-url
           - name: BUTLER_REPO
             value: "s3://embargo@rubin-summit-users/butler.yaml"
           

--- a/kubernetes/overlays/prod/lsstcam-job/kustomization.yaml
+++ b/kubernetes/overlays/prod/lsstcam-job/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/lsst-dm/consdb-transformed-efd
-  newTag: "26.2.1"
+  newTag: "26.3.4"
 
 resources:
 - ../../../base/job/

--- a/kubernetes/overlays/prod/lsstcam-job/kustomization.yaml
+++ b/kubernetes/overlays/prod/lsstcam-job/kustomization.yaml
@@ -17,6 +17,7 @@ secretGenerator:
   - s3-profile-embargo=etc/.secrets/s3-profile-embargo
   - usdf-efd-password=etc/.secrets/usdf-efd-password
   - consdb-url=etc/.secrets/consdb-url
+  - consdb-int-url=etc/.secrets/consdb-int-url
 
 namespace: prod-lsstcam
 

--- a/kubernetes/overlays/prod/lsstcomcam-cronjob/cronjob.yaml
+++ b/kubernetes/overlays/prod/lsstcomcam-cronjob/cronjob.yaml
@@ -24,5 +24,10 @@ spec:
                 secretKeyRef:
                   name: efd-transform-secrets
                   key: consdb-url
+            - name: CONSDB_INT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: efd-transform-secrets
+                  key: consdb-int-url
             - name: BUTLER_REPO
               value: "s3://embargo@rubin-summit-users/butler.yaml"

--- a/kubernetes/overlays/prod/lsstcomcam-cronjob/failure-monitor.yaml
+++ b/kubernetes/overlays/prod/lsstcomcam-cronjob/failure-monitor.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: transformed-efd-prod-failure-monitor
 spec:
-  schedule: "*/60 * * * *"
+  schedule: "0 */6 * * *"
   jobTemplate:
     spec:
       template:

--- a/kubernetes/overlays/prod/lsstcomcam-cronjob/failure-monitor.yaml
+++ b/kubernetes/overlays/prod/lsstcomcam-cronjob/failure-monitor.yaml
@@ -15,12 +15,17 @@ spec:
               value: "LSSTComCam"
             - name: CONFIG_FILE
               value: "/opt/lsst/software/stack/python/lsst/consdb/transformed_efd/config/config_lsstcomcam.yaml"
-            - name: RESUME
-              value: "--resume"     # -R or --resume Flag to resume processing from the last successful chunk              
+            - name: FAILURE_MONITOR
+              value: "--failure-monitor --monitor-window-days 7"
             - name: CONSDB_URL
               valueFrom:
                 secretKeyRef:
                   name: efd-transform-secrets
                   key: consdb-url
+            - name: CONSDB_INT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: efd-transform-secrets
+                  key: consdb-int-url
             - name: BUTLER_REPO
               value: "s3://embargo@rubin-summit-users/butler.yaml"

--- a/kubernetes/overlays/prod/lsstcomcam-cronjob/kustomization.yaml
+++ b/kubernetes/overlays/prod/lsstcomcam-cronjob/kustomization.yaml
@@ -17,6 +17,7 @@ secretGenerator:
   - s3-profile-embargo=etc/.secrets/s3-profile-embargo
   - usdf-efd-password=etc/.secrets/usdf-efd-password
   - consdb-url=etc/.secrets/consdb-url
+  - consdb-int-url=etc/.secrets/consdb-int-url
 
 namespace: prod-lsstcomcam
 

--- a/kubernetes/overlays/prod/lsstcomcam-cronjob/kustomization.yaml
+++ b/kubernetes/overlays/prod/lsstcomcam-cronjob/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/lsst-dm/consdb-transformed-efd
-  newTag: "26.2.1"
+  newTag: "26.3.4"
 
 resources:
 - ../../../base/cronjob/

--- a/kubernetes/overlays/prod/lsstcomcam-cronjob/patch.yaml
+++ b/kubernetes/overlays/prod/lsstcomcam-cronjob/patch.yaml
@@ -1,0 +1,1 @@
+failure-monitor.yaml

--- a/kubernetes/overlays/prod/lsstcomcam-job/job.yaml
+++ b/kubernetes/overlays/prod/lsstcomcam-job/job.yaml
@@ -25,6 +25,11 @@ spec:
               secretKeyRef:
                 name: efd-transform-secrets
                 key: consdb-url
+          - name: CONSDB_INT_URL
+            valueFrom:
+              secretKeyRef:
+                name: efd-transform-secrets
+                key: consdb-int-url
           - name: BUTLER_REPO
             value: "s3://embargo@rubin-summit-users/butler.yaml"
           

--- a/kubernetes/overlays/prod/lsstcomcam-job/kustomization.yaml
+++ b/kubernetes/overlays/prod/lsstcomcam-job/kustomization.yaml
@@ -17,6 +17,7 @@ secretGenerator:
   - s3-profile-embargo=etc/.secrets/s3-profile-embargo
   - usdf-efd-password=etc/.secrets/usdf-efd-password
   - consdb-url=etc/.secrets/consdb-url
+  - consdb-int-url=etc/.secrets/consdb-int-url
 
 namespace: prod-lsstcomcam
 

--- a/kubernetes/overlays/prod/lsstcomcam-job/kustomization.yaml
+++ b/kubernetes/overlays/prod/lsstcomcam-job/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/lsst-dm/consdb-transformed-efd
-  newTag: "26.2.1"
+  newTag: "26.3.4"
 
 resources:
 - ../../../base/job/


### PR DESCRIPTION
- Add **internal ConsDB URL** support: `CONSDB_INT_URL` from secrets, wired into prod jobs/cronjobs and secret generation/Makefile lists; job/cronjob templates pass it to `transform_efd.py` when set.
- **CronJob template:** replace `RESUME` with **`FAILURE_MONITOR`**; failure-monitor overlays use `--failure-monitor --monitor-window-days 7` instead of `--resume`. 
- New tag: 26.3.4

These changes are implemented to conform with https://github.com/lsst-dm/consdb/pull/111 Transformed EFD service.
